### PR TITLE
Parallelize Azure Key Vault secret loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Here's why: our application settings, one line, done right. No more scattered `o
 
 - **Great defaults from day one:** It automatically looks for settings files and environment variables, with recommended configurations and one line of code.
 - **Rust-powered core:** Built with Rust under the hood for speed, reliability, and low runtime overhead.
-- **Secret stores:** Azure Key Vault, AWS Secrets Manager and GCP Secret Manager integrations are available with one line of code, with safe authentication.
+- **Secret stores:** Load secrets and certificates from Azure Key Vault, AWS Secrets Manager and GCP Secret Manager, with one line of code and safe authentication.
 - **Automatic reloads:** Keep settings up to date by automatically reloading them, with no need to restart the application or deploy a new version.
 - **Pydantic models:** Load application settings directly into models.
 - **A practical replacement:** Replace `pydantic-settings` and `python-dotenv` with one centralized, provider-agnostic (no vendor lock-in) settings library.
@@ -480,6 +480,8 @@ settings_manager.add_environment_variables()
 Keys are normalized to snake case, and `__` is replaced with `.`. For example, `DATABASE__HOST` maps to `database.host`.
 
 ### Azure Key Vault
+
+Read secrets and [certificates](https://learn.microsoft.com/en-us/azure/key-vault/certificates/about-certificates#composition-of-a-certificate) from Azure Key Vault.
 
 ```python
 settings_manager.add_azure_key_vault(

--- a/src/azure_key_vault.rs
+++ b/src/azure_key_vault.rs
@@ -1,6 +1,7 @@
 mod azure_key_vault_settings_provider;
 mod azure_key_vault_settings_source;
 mod default_azure_credential;
+mod parallel_secret_loader;
 mod remove_user_agent;
 
 pub use azure_key_vault_settings_provider::AzureKeyVaultSettingsProvider;

--- a/src/azure_key_vault/azure_key_vault_settings_provider.rs
+++ b/src/azure_key_vault/azure_key_vault_settings_provider.rs
@@ -1,8 +1,9 @@
 use arc_swap::ArcSwap;
 use azure_identity::ClientSecretCredential;
+use azure_security_keyvault_secrets::ResourceExt;
+use azure_security_keyvault_secrets::SecretClient;
 use azure_security_keyvault_secrets::SecretClientOptions;
-use azure_security_keyvault_secrets::models::Secret;
-use azure_security_keyvault_secrets::{ResourceExt, SecretClient, models::SecretProperties};
+use azure_security_keyvault_secrets::models::{Secret, SecretProperties};
 use futures::TryStreamExt;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
@@ -15,6 +16,7 @@ use tokio::sync::{Mutex, OnceCell};
 use tokio_util::sync::CancellationToken;
 
 use crate::azure_key_vault::default_azure_credential::DefaultAzureCredential;
+use crate::azure_key_vault::parallel_secret_loader::ParallelSecretLoader;
 use crate::azure_key_vault::remove_user_agent::RemoveUserAgent;
 use crate::core::{ModelRegistry, PythonSettingsProvider, SettingLookup, SettingsProvider};
 
@@ -173,6 +175,35 @@ impl AzureKeyVaultSettingsProvider {
         tenant_id.is_some() || client_id.is_some() || client_secret.is_some()
     }
 
+    fn add_secret_to_loader(
+        secret_properties: &SecretProperties,
+        loaded_secrets: &mut BTreeMap<String, Secret>,
+        new_loaded_secrets: &mut BTreeMap<String, Secret>,
+        parallel_secret_loader: &mut ParallelSecretLoader,
+    ) -> PyResult<()> {
+        if !Self::is_secret_enabled(secret_properties) {
+            return Ok(());
+        }
+
+        let secret_name = Self::extract_secret_name(secret_properties)?;
+
+        if let Some(loaded_secret) = loaded_secrets.get(&secret_name)
+            && Self::is_secret_up_to_date(loaded_secret, secret_properties)
+        {
+            let loaded_secret = loaded_secrets.remove(&secret_name).ok_or_else(|| {
+                PyRuntimeError::new_err(
+                    "Cached Azure Key Vault secret disappeared while reloading secrets",
+                )
+            })?;
+
+            new_loaded_secrets.insert(secret_name, loaded_secret);
+            return Ok(());
+        }
+
+        parallel_secret_loader.add_secret_to_load(secret_name);
+        Ok(())
+    }
+
     fn is_secret_enabled(secret_properties: &SecretProperties) -> bool {
         secret_properties
             .attributes
@@ -202,77 +233,47 @@ impl AzureKeyVaultSettingsProvider {
                 .and_then(|attributes| attributes.updated)
     }
 
-    async fn add_secret(
-        secret_client: &SecretClient,
-        loaded_secrets: Option<&BTreeMap<String, Secret>>,
-        secret_properties: SecretProperties,
-        new_loaded_secrets: &mut BTreeMap<String, Secret>,
-        url: &str,
-    ) -> PyResult<()> {
-        if !Self::is_secret_enabled(&secret_properties) {
-            return Ok(());
-        }
-
-        let secret_name = Self::extract_secret_name(&secret_properties)?;
-        let loaded_secret =
-            loaded_secrets.and_then(|loaded_secrets| loaded_secrets.get(&secret_name));
-
-        if let Some(loaded_secret) = loaded_secret
-            && Self::is_secret_up_to_date(loaded_secret, &secret_properties)
-        {
-            new_loaded_secrets.insert(secret_name, loaded_secret.clone());
-            return Ok(());
-        }
-
-        let retrieved_secret = Self::retrieve_secret(secret_client, &secret_name, url).await?;
-        new_loaded_secrets.insert(secret_name, retrieved_secret);
-        Ok(())
-    }
-
-    async fn retrieve_secret(
-        secret_client: &SecretClient,
-        secret_name: &str,
-        url: &str,
-    ) -> PyResult<Secret> {
-        let secret_response = secret_client.get_secret(secret_name, None).await.map_err(
-            |error| {
-                PyRuntimeError::new_err(format!(
-                    "Failed to read secret '{secret_name}' from Azure Key Vault '{url}': {error}",
-                ))
-            },
-        )?;
-        secret_response.into_model().map_err(|error| {
-            PyRuntimeError::new_err(format!(
-                "Failed to deserialize Azure Key Vault secret '{secret_name}': {error}",
-            ))
-        })
-    }
-
     fn update_secrets(
         secrets_cache: &ArcSwap<SecretsCache>,
-        new_loaded_secrets: BTreeMap<String, Secret>,
+        loaded_secrets_cache: &SecretsCache,
+        mut new_loaded_secrets: BTreeMap<String, Secret>,
+        loaded_secrets: &BTreeMap<String, Secret>,
+        new_loaded_secrets_from_loader: BTreeMap<String, Secret>,
         model_registry: &OnceCell<Py<ModelRegistry>>,
     ) -> PyResult<()> {
-        let mut secret_values = new_loaded_secrets
-            .iter()
-            .map(|(secret_name, secret)| (secret_name.clone(), secret.value.clone()))
-            .collect::<BTreeMap<String, Option<String>>>();
-        Self::normalize_keys(&mut secret_values);
+        let has_loaded_secrets = !new_loaded_secrets_from_loader.is_empty();
+        let has_removed_secrets = !loaded_secrets.is_empty();
 
-        let updated_secrets_cache = Python::attach(|py| -> PyResult<SecretsCache> {
-            let data = PyDict::new(py);
+        // Reload is needed if we're loading new secrets that weren't previously cached,
+        // or if we're removing secrets that were previously cached but are no longer present in the Azure Key Vault
+        if has_loaded_secrets || has_removed_secrets {
+            new_loaded_secrets.extend(new_loaded_secrets_from_loader);
+            let mut secret_values = new_loaded_secrets
+                .iter()
+                .map(|(secret_name, secret)| (secret_name.clone(), secret.value.clone()))
+                .collect::<BTreeMap<String, Option<String>>>();
+            Self::normalize_keys(&mut secret_values);
 
-            for (secret_name, secret_value) in secret_values {
-                data.set_item(secret_name, secret_value)?;
+            let updated_secrets_cache = Python::attach(|py| -> PyResult<SecretsCache> {
+                let data = PyDict::new(py);
+
+                for (secret_name, secret_value) in secret_values {
+                    data.set_item(secret_name, secret_value)?;
+                }
+
+                Ok(SecretsCache {
+                    data: data.unbind(),
+                    loaded_secrets: Some(new_loaded_secrets),
+                })
+            })?;
+            secrets_cache.store(Arc::new(updated_secrets_cache));
+            let is_first_load = loaded_secrets_cache.loaded_secrets.is_none();
+
+            if !is_first_load {
+                Python::attach(|py| Self::on_reload(py, model_registry));
             }
+        }
 
-            Ok(SecretsCache {
-                data: data.unbind(),
-                loaded_secrets: Some(new_loaded_secrets),
-            })
-        })?;
-        secrets_cache.store(Arc::new(updated_secrets_cache));
-        Python::attach(|py| Self::on_reload(py, model_registry));
         Ok(())
     }
 
@@ -330,7 +331,11 @@ impl AzureKeyVaultSettingsProvider {
                 })?;
         let mut new_loaded_secrets: BTreeMap<String, Secret> = BTreeMap::new();
         let loaded_secrets_cache = secrets_cache.load_full();
-        let loaded_secrets = loaded_secrets_cache.loaded_secrets.as_ref();
+        let mut loaded_secrets = loaded_secrets_cache
+            .loaded_secrets
+            .clone()
+            .unwrap_or_default();
+        let mut parallel_secret_loader = ParallelSecretLoader::new(secret_client);
 
         while let Some(secret_properties) =
             secret_properties_pager.try_next().await.map_err(|error| {
@@ -339,17 +344,23 @@ impl AzureKeyVaultSettingsProvider {
                 ))
             })?
         {
-            Self::add_secret(
-                secret_client,
-                loaded_secrets,
-                secret_properties,
+            Self::add_secret_to_loader(
+                &secret_properties,
+                &mut loaded_secrets,
                 &mut new_loaded_secrets,
-                url,
-            )
-            .await?;
+                &mut parallel_secret_loader,
+            )?;
         }
 
-        Self::update_secrets(secrets_cache, new_loaded_secrets, model_registry)
+        let new_loaded_secrets_from_loader = parallel_secret_loader.load_all_secrets(url).await?;
+        Self::update_secrets(
+            secrets_cache,
+            &loaded_secrets_cache,
+            new_loaded_secrets,
+            &loaded_secrets,
+            new_loaded_secrets_from_loader,
+            model_registry,
+        )
     }
 }
 
@@ -373,10 +384,9 @@ impl SettingsProvider for AzureKeyVaultSettingsProvider {
     }
 
     async fn reload(&self) -> PyResult<()> {
-        let secret_client = Arc::clone(&self.secret_client);
         let secrets_cache = Arc::clone(&self.secrets_cache);
         Self::reload_secrets(
-            &secret_client,
+            &self.secret_client,
             &secrets_cache,
             &self.url,
             &self.model_registry,
@@ -402,6 +412,7 @@ impl fmt::Display for AzureKeyVaultSettingsProvider {
 #[cfg(test)]
 mod tests {
     use super::{AzureKeyVaultSettingsProvider, SecretsCache};
+    use crate::azure_key_vault::parallel_secret_loader::ParallelSecretLoader;
     use crate::core::{ModelRegistry, SettingsProvider};
     use arc_swap::ArcSwap;
     use async_trait::async_trait;
@@ -456,10 +467,6 @@ mod tests {
                 self.response_body.clone(),
             ))
         }
-    }
-
-    fn create_secret_client_mock(url: &str) -> SecretClient {
-        SecretClient::new(url, Arc::new(CredentialMock), None).unwrap()
     }
 
     #[test]
@@ -680,33 +687,38 @@ mod tests {
         ));
     }
 
-    #[tokio::test]
-    async fn test_skip_disabled_secret_when_adding_secret() {
-        let secret_client = create_secret_client_mock("https://example.vault.azure.net");
+    #[test]
+    fn test_skip_disabled_secret_when_adding_to_loader() {
         let mut secret_properties = SecretProperties::default();
         secret_properties.attributes = Some(SecretAttributes {
             enabled: Some(false),
             ..Default::default()
         });
-        let mut new_loaded_secrets = BTreeMap::new();
-
-        AzureKeyVaultSettingsProvider::add_secret(
-            &secret_client,
-            None,
-            secret_properties,
-            &mut new_loaded_secrets,
+        let secret_client = SecretClient::new(
             "https://example.vault.azure.net",
+            Arc::new(CredentialMock),
+            None,
         )
-        .await
+        .unwrap();
+        let mut parallel_secret_loader = ParallelSecretLoader::new(&secret_client);
+        let mut new_loaded_secrets = BTreeMap::new();
+        let mut loaded_secrets = BTreeMap::new();
+
+        AzureKeyVaultSettingsProvider::add_secret_to_loader(
+            &secret_properties,
+            &mut loaded_secrets,
+            &mut new_loaded_secrets,
+            &mut parallel_secret_loader,
+        )
         .unwrap();
 
+        assert!(parallel_secret_loader.is_empty());
         assert!(new_loaded_secrets.is_empty());
     }
 
-    #[tokio::test]
-    async fn test_reuse_cached_secret_when_adding_up_to_date_secret() {
+    #[test]
+    fn test_reuse_cached_secret_when_adding_to_loader() {
         let expected_cache_value = "cached-value";
-        let secret_client = create_secret_client_mock("https://example.vault.azure.net");
         let update_time = azure_core::time::OffsetDateTime::UNIX_EPOCH;
         let secret_name: String = String::from("cached-secret");
         let mut cached_secret = Secret::default();
@@ -715,7 +727,7 @@ mod tests {
             updated: Some(update_time),
             ..Default::default()
         });
-        let loaded_secrets = BTreeMap::from([(secret_name.clone(), cached_secret)]);
+        let mut loaded_secrets = BTreeMap::from([(secret_name.clone(), cached_secret)]);
         let mut secret_properties = SecretProperties::default();
         secret_properties.id = Some(format!(
             "https://example.vault.azure.net/secrets/{secret_name}/version"
@@ -725,18 +737,25 @@ mod tests {
             updated: Some(update_time),
             ..Default::default()
         });
+        let secret_client = SecretClient::new(
+            "https://example.vault.azure.net",
+            Arc::new(CredentialMock),
+            None,
+        )
+        .unwrap();
+        let mut parallel_secret_loader = ParallelSecretLoader::new(&secret_client);
         let mut new_loaded_secrets = BTreeMap::new();
 
-        AzureKeyVaultSettingsProvider::add_secret(
-            &secret_client,
-            Some(&loaded_secrets),
-            secret_properties,
+        AzureKeyVaultSettingsProvider::add_secret_to_loader(
+            &secret_properties,
+            &mut loaded_secrets,
             &mut new_loaded_secrets,
-            "https://example.vault.azure.net",
+            &mut parallel_secret_loader,
         )
-        .await
         .unwrap();
 
+        assert!(parallel_secret_loader.is_empty());
+        assert!(loaded_secrets.is_empty());
         assert_eq!(
             new_loaded_secrets
                 .get(&secret_name)
@@ -745,7 +764,7 @@ mod tests {
         );
     }
     #[tokio::test]
-    async fn test_retrieve_secret_when_cached_secret_is_missing() {
+    async fn test_retrieve_secret_when_loading_uncached_secret() {
         let expected_secret_name = "missing-secret";
         let expected_secret_value = "retrieved-value";
         let url = "https://example.vault.azure.net";
@@ -761,28 +780,13 @@ mod tests {
         let secret_client =
             SecretClient::new(url, Arc::new(CredentialMock), Some(secret_client_options)).unwrap();
 
-        let mut secret_properties = SecretProperties::default();
-        secret_properties.id = Some(format!(
-            "https://example.vault.azure.net/secrets/{expected_secret_name}/version"
-        ));
-        secret_properties.attributes = Some(SecretAttributes {
-            enabled: Some(true),
-            ..Default::default()
-        });
-        let mut new_loaded_secrets = BTreeMap::new();
-
-        AzureKeyVaultSettingsProvider::add_secret(
-            &secret_client,
-            None,
-            secret_properties,
-            &mut new_loaded_secrets,
-            url,
-        )
-        .await
-        .unwrap();
+        let mut parallel_secret_loader = ParallelSecretLoader::new(&secret_client);
+        parallel_secret_loader.add_secret_to_load(expected_secret_name.to_owned());
+        let loaded_secrets_from_loader =
+            parallel_secret_loader.load_all_secrets(url).await.unwrap();
 
         assert_eq!(
-            new_loaded_secrets
+            loaded_secrets_from_loader
                 .get(expected_secret_name)
                 .and_then(|secret| secret.value.as_deref()),
             Some(expected_secret_value)

--- a/src/azure_key_vault/azure_key_vault_settings_provider.rs
+++ b/src/azure_key_vault/azure_key_vault_settings_provider.rs
@@ -366,10 +366,8 @@ impl AzureKeyVaultSettingsProvider {
 
 impl Drop for AzureKeyVaultSettingsProvider {
     fn drop(&mut self) {
-        let schedule_reload_cancellation_token = self
-            .schedule_reload_cancellation_token
-            .blocking_lock()
-            .take();
+        let schedule_reload_cancellation_token =
+            self.schedule_reload_cancellation_token.get_mut().take();
 
         if let Some(cancellation_token) = schedule_reload_cancellation_token {
             cancellation_token.cancel();

--- a/src/azure_key_vault/parallel_secret_loader.rs
+++ b/src/azure_key_vault/parallel_secret_loader.rs
@@ -1,0 +1,190 @@
+use azure_security_keyvault_secrets::SecretClient;
+use azure_security_keyvault_secrets::models::Secret;
+use futures::{StreamExt, TryStreamExt};
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
+use std::collections::BTreeMap;
+
+pub(crate) struct ParallelSecretLoader<'a> {
+    secret_client: &'a SecretClient,
+    secret_names: Vec<String>,
+}
+
+impl<'a> ParallelSecretLoader<'a> {
+    const PARALLELISM_LEVEL: usize = 32;
+
+    pub(crate) fn new(secret_client: &'a SecretClient) -> Self {
+        Self {
+            secret_client,
+            secret_names: Vec::new(),
+        }
+    }
+
+    pub(crate) fn add_secret_to_load(&mut self, secret_name: String) {
+        self.secret_names.push(secret_name);
+    }
+
+    pub(crate) async fn load_all_secrets(self, url: &str) -> PyResult<BTreeMap<String, Secret>> {
+        let mut loaded_secrets = futures::stream::iter(
+            self.secret_names
+                .into_iter()
+                .map(|secret_name| Self::retrieve_secret(self.secret_client, secret_name, url)),
+        )
+        .buffer_unordered(Self::PARALLELISM_LEVEL);
+        let mut new_loaded_secrets = BTreeMap::new();
+
+        while let Some((secret_name, secret)) = loaded_secrets.try_next().await? {
+            new_loaded_secrets.insert(secret_name, secret);
+        }
+
+        Ok(new_loaded_secrets)
+    }
+
+    async fn retrieve_secret(
+        secret_client: &SecretClient,
+        secret_name: String,
+        url: &str,
+    ) -> PyResult<(String, Secret)> {
+        let secret_response = secret_client.get_secret(&secret_name, None).await.map_err(
+            |error| {
+                PyRuntimeError::new_err(format!(
+                    "Failed to read secret '{secret_name}' from Azure Key Vault '{url}': {error}",
+                ))
+            },
+        )?;
+
+        let secret = secret_response.into_model().map_err(|error| {
+            PyRuntimeError::new_err(format!(
+                "Failed to deserialize Azure Key Vault secret '{secret_name}': {error}",
+            ))
+        })?;
+
+        Ok((secret_name, secret))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.secret_names.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ParallelSecretLoader;
+    use async_trait::async_trait;
+    use azure_core::credentials::{AccessToken, TokenCredential, TokenRequestOptions};
+    use azure_core::http::{
+        AsyncRawResponse, ClientOptions, HttpClient, Request, StatusCode, Transport,
+        headers::Headers,
+    };
+    use azure_security_keyvault_secrets::{SecretClient, SecretClientOptions};
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+    use std::time::Duration;
+
+    #[derive(Debug)]
+    struct CredentialMock;
+
+    #[async_trait]
+    impl TokenCredential for CredentialMock {
+        async fn get_token(
+            &self,
+            _scopes: &[&str],
+            _options: Option<TokenRequestOptions<'_>>,
+        ) -> azure_core::Result<AccessToken> {
+            Err(azure_core::Error::with_message(
+                azure_core::error::ErrorKind::Credential,
+                "Test credential must not acquire a token",
+            ))
+        }
+    }
+
+    #[derive(Debug)]
+    struct HttpClientMock {
+        active_requests: Arc<AtomicUsize>,
+        maximum_active_requests: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl HttpClient for HttpClientMock {
+        async fn execute_request(
+            &self,
+            _request: &Request,
+        ) -> azure_core::Result<AsyncRawResponse> {
+            let active_requests = self.active_requests.fetch_add(1, Ordering::SeqCst) + 1;
+            self.maximum_active_requests
+                .fetch_max(active_requests, Ordering::SeqCst);
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            self.active_requests.fetch_sub(1, Ordering::SeqCst);
+
+            Ok(AsyncRawResponse::from_bytes(
+                StatusCode::Ok,
+                Headers::default(),
+                br#"{"value":"retrieved-value"}"#.to_vec(),
+            ))
+        }
+    }
+
+    #[test]
+    fn test_create_loader_with_no_secret_names() {
+        let secret_client = SecretClient::new(
+            "https://example.vault.azure.net",
+            Arc::new(CredentialMock),
+            None,
+        )
+        .unwrap();
+
+        let parallel_secret_loader = ParallelSecretLoader::new(&secret_client);
+
+        assert!(parallel_secret_loader.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_load_queued_secrets_in_parallel() {
+        let expected_loaded_secrets_count = 2;
+        let expected_first_secret_name = "first-secret";
+        let expected_second_secret_name = "second-secret";
+        let expected_secret_value = "retrieved-value";
+        let active_requests = Arc::new(AtomicUsize::new(0));
+        let maximum_active_requests = Arc::new(AtomicUsize::new(0));
+        let url = "https://example.vault.azure.net";
+        let secret_client_options = SecretClientOptions {
+            client_options: ClientOptions {
+                transport: Some(Transport::new(Arc::new(HttpClientMock {
+                    active_requests: Arc::clone(&active_requests),
+                    maximum_active_requests: Arc::clone(&maximum_active_requests),
+                }))),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let secret_client =
+            SecretClient::new(url, Arc::new(CredentialMock), Some(secret_client_options)).unwrap();
+        let mut parallel_secret_loader = ParallelSecretLoader::new(&secret_client);
+        parallel_secret_loader.add_secret_to_load(String::from(expected_first_secret_name));
+        parallel_secret_loader.add_secret_to_load(String::from(expected_second_secret_name));
+
+        let loaded_secrets_from_loader =
+            parallel_secret_loader.load_all_secrets(url).await.unwrap();
+
+        assert_eq!(
+            loaded_secrets_from_loader.len(),
+            expected_loaded_secrets_count
+        );
+        assert_eq!(
+            loaded_secrets_from_loader
+                .get(expected_first_secret_name)
+                .and_then(|secret| secret.value.as_deref()),
+            Some(expected_secret_value)
+        );
+        assert_eq!(
+            loaded_secrets_from_loader
+                .get(expected_second_secret_name)
+                .and_then(|secret| secret.value.as_deref()),
+            Some(expected_secret_value)
+        );
+        assert_eq!(maximum_active_requests.load(Ordering::SeqCst), 2);
+    }
+}


### PR DESCRIPTION
**2-4x speedup**, with two executions per test case.

  | Current implementation | Parallelized implementation
-- | -- | --
Time in seconds for 30 secrets | 5.7, 5.1 | 3, 2.5
Time in seconds for 60 secrets | 8.5, 8.9 | 2.6, 2.7